### PR TITLE
add auto tcti config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "vptmtest"
+name = "vtpmtest"
 version = "0.1.0"
 dependencies = [
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "vptmtest"
+name = "vtpmtest"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
Fall back to default values if TCTI environment variable is not set. Removes the requirement to export before running in majority of cases.